### PR TITLE
会場案内の長いURLを折り返すように修正

### DIFF
--- a/app/views/admin/venues/show.html.erb
+++ b/app/views/admin/venues/show.html.erb
@@ -44,7 +44,7 @@
         <% if @venue.announcement_detail.present? %>
           <div class="bg-gray-50 px-4 py-5 sm:px-6">
             <dt class="text-sm font-medium text-gray-500 mb-1"><%= Venue.human_attribute_name(:announcement_detail) %></dt>
-            <dd class="text-sm text-gray-900"><%= format_with_links(@venue.announcement_detail) %></dd>
+            <dd class="text-sm text-gray-900 break-words"><%= format_with_links(@venue.announcement_detail) %></dd>
           </div>
         <% end %>
       </dl>

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -12,7 +12,7 @@
   <%= form_with(model: @attendance, url: event_attendance_path(@event), method: :patch, class: "bg-white shadow sm:rounded-lg") do |form| %>
     <div class="px-4 py-5 sm:p-6 space-y-6">
       <% if @event.venue.announcement_detail.present? %>
-        <div class="text-sm text-gray-700"><%= format_with_links(@event.venue.announcement_detail) %></div>
+        <div class="text-sm text-gray-700 break-words"><%= format_with_links(@event.venue.announcement_detail) %></div>
       <% end %>
 
       <!-- ステータス -->


### PR DESCRIPTION
- 参加登録画面と管理画面の会場詳細にbreak-wordsを追加