### PR TITLE
ユーザーの最終アクセス日時を記録・表示

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -23,6 +23,8 @@ module Authentication
 
     def resume_session
       Current.session ||= find_session_by_cookie
+      Current.session&.user&.update_column(:last_accessed_at, Time.current)
+      Current.session
     end
 
     def find_session_by_cookie

--- a/app/views/admin/members/index.html.erb
+++ b/app/views/admin/members/index.html.erb
@@ -21,6 +21,9 @@
                   <% if member.user.admin? %>
                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 whitespace-nowrap flex-shrink-0">管理者</span>
                   <% end %>
+                  <% if member.user.last_accessed_at %>
+                    <span class="text-xs text-gray-400"><%= l(member.user.last_accessed_at, format: :short) %></span>
+                  <% end %>
                 </div>
                 <svg class="h-5 w-5 text-gray-400 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                   <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>

--- a/app/views/admin/members/show.html.erb
+++ b/app/views/admin/members/show.html.erb
@@ -60,12 +60,15 @@
           </dd>
         </div>
 
-        <% if @member.description.present? %>
-          <div class="bg-gray-50 px-4 py-5 sm:px-6">
-            <dt class="text-sm font-medium text-gray-500 mb-1">自己紹介</dt>
-            <dd class="text-sm text-gray-900"><%= simple_format(@member.description, sanitize: true) %></dd>
-          </div>
-        <% end %>
+        <div class="bg-gray-50 px-4 py-5 sm:px-6">
+          <dt class="text-sm font-medium text-gray-500 mb-1">自己紹介</dt>
+          <dd class="text-sm text-gray-900"><%= @member.description.present? ? simple_format(@member.description, sanitize: true) : "-" %></dd>
+        </div>
+
+        <div class="bg-white px-4 py-5 sm:px-6">
+          <dt class="text-sm font-medium text-gray-500 mb-1"><%= User.human_attribute_name(:last_accessed_at) %></dt>
+          <dd class="text-sm text-gray-900"><%= @member.user.last_accessed_at ? l(@member.user.last_accessed_at, format: :long) : "-" %></dd>
+        </div>
       </dl>
     </div>
   </div>

--- a/config/locales/models.ja.yml
+++ b/config/locales/models.ja.yml
@@ -18,6 +18,7 @@ ja:
         role: "権限"
         confirmed_at: "確認日時"
         disabled_at: "無効日時"
+        last_accessed_at: "最終アクセス"
       player:
         name: "お名前"
         organization_name: "所属団体"

--- a/db/migrate/20260211211831_add_last_accessed_at_to_users.rb
+++ b/db/migrate/20260211211831_add_last_accessed_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastAccessedAtToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :last_accessed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_18_234347) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_11_211831) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -103,6 +103,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_18_234347) do
     t.datetime "created_at", null: false
     t.datetime "disabled_at"
     t.string "email_address", null: false
+    t.datetime "last_accessed_at"
     t.string "password_digest", null: false
     t.boolean "receives_announcements", default: true
     t.string "role"


### PR DESCRIPTION
セッション復元時にlast_accessed_atを更新し、管理画面のメンバー一覧・詳細から確認できるようにした