### PR TITLE
メンバー一覧の並び順を管理者優先・最終アクセス新しい順に変更

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -2,7 +2,12 @@ class Admin::MembersController < Admin::BaseController
   before_action :set_member, only: %i[show edit update destroy]
 
   def index
-    @members = Member.includes(:user).order(:name)
+    @members = Member.joins(:user)
+                     .order(
+                       Arel.sql("CASE users.role WHEN 'admin' THEN 0 ELSE 1 END"),
+                       Arel.sql("users.last_accessed_at DESC NULLS LAST"),
+                       Arel.sql("users.created_at DESC")
+                     )
   end
 
   def show


### PR DESCRIPTION
管理者を上に、管理者同士・一般ユーザー同士は最終アクセスが新しい順、
最終アクセスがない場合は登録日時が新しい順に並べる。