### PR TITLE
サインアップ引き継ぎ時に他のメールアドレスを削除する

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -30,8 +30,7 @@ class RegistrationsController < ApplicationController
       @user.assign_attributes(user_params.except(:email_address))
       @user.role = :member
 
-      if @user.save
-        existing_mail_address.update!(confirmed_at: nil)
+      if @user.takeover_signup(existing_mail_address)
         send_confirmation_and_redirect(existing_mail_address) and return
       else
         render :new, status: :unprocessable_entity

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,6 +92,17 @@ class User < ApplicationRecord
     mail_addresses.first&.confirm!
   end
 
+  def takeover_signup(mail_address)
+    transaction do
+      save!
+      mail_addresses.where.not(id: mail_address.id).destroy_all
+      mail_address.update!(confirmed_at: nil)
+    end
+    true
+  rescue ActiveRecord::RecordInvalid
+    false
+  end
+
   def confirm_new_mail_addresses
     mail_addresses.each do |ma|
       ma.confirmed_at = Time.current if ma.new_record? && !ma.marked_for_destruction?

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -37,13 +37,18 @@ RSpec.describe "Registrations", type: :request do
     end
 
     context "既存ユーザーが仮登録（管理者作成・パスワードなし）の場合" do
+      let(:other_mail_address_count) { 0 }
       let!(:existing_user) do
-        User.create!(
+        user = User.create!(
           email_address: "newuser@example.com",
           provisional: true,
           role: "member",
           confirmed_at: Time.current
         )
+        other_mail_address_count.times do |i|
+          user.mail_addresses.create!(address: "other#{i}@example.com", confirmed_at: Time.current)
+        end
+        user
       end
       let!(:existing_member) { Member.create!(name: "管理者が設定した名前", user: existing_user) }
 
@@ -60,6 +65,19 @@ RSpec.describe "Registrations", type: :request do
         expect(existing_user.member.organization_name).to eq "テスト団体"
         expect(existing_user.confirmed_at).to be_nil
         expect(existing_user.confirmation_token).to be_present
+      end
+
+      context "複数のメールアドレスがある場合" do
+        let(:other_mail_address_count) { 2 }
+
+        it "サインアップに使用したメールアドレス以外は削除される" do
+          expect {
+            post signup_path(token: signup_token), params: { user: user_params }
+          }.to change { existing_user.mail_addresses.count }.from(3).to(1)
+
+          existing_user.reload
+          expect(existing_user.mail_addresses.sole.address).to eq "newuser@example.com"
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
- 仮登録ユーザーが複数メールアドレスを持つ場合、サインアップ引き継ぎ時に入力されたメールアドレス以外を物理削除する
- save・メアド削除・確認状態リセットをトランザクションで一括処理するUser#takeover_signupメソッドを追加
- 複数メアドが残ると確認待ち状態が正しく表示されない問題を解消

## Test plan
- [x] 仮登録ユーザー（複数メアド）でサインアップ → 入力したメアド以外が削除される
- [x] 仮登録ユーザー（単一メアド）でサインアップ → 従来通り動作する