### PR TITLE
既存ユーザーのsave時にパスワード必須バリデーションが走るリグレッションを修正

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -83,10 +83,6 @@ class Admin::UsersController < Admin::BaseController
       :disabled, :role, :password, :password_confirmation, :provisional,
       mail_addresses_attributes: [ :id, :address, :_destroy ]
     )
-    if permitted[:password].blank?
-      permitted.delete(:password)
-      permitted.delete(:password_confirmation)
-    end
     permitted.delete(:role) if @user == current_user
     permitted
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -17,14 +17,9 @@ class ProfilesController < ApplicationController
   private
 
   def profile_params
-    permitted = params.require(:user).permit(
+    params.require(:user).permit(
       :name, :organization_name, :rank, :description,
       :receives_announcements, :password, :password_confirmation
     )
-    if permitted[:password].blank?
-      permitted.delete(:password)
-      permitted.delete(:password_confirmation)
-    end
-    permitted
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
 
   validates :password, length: { maximum: 72 }, allow_blank: true
   validates :password, confirmation: true, allow_blank: true
-  validates :password, presence: true, unless: :provisional?
+  validates :password, presence: true, unless: -> { provisional? || persisted? }
 
   scope :active, -> { where(disabled_at: nil) }
   scope :receives_announcements, -> { where(receives_announcements: true) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -105,5 +105,19 @@ RSpec.describe User, type: :model do
         it { is_expected.to be_valid }
       end
     end
+
+    context "既存ユーザーの場合" do
+      let(:user) do
+        u = User.new(password: "password123", role: "member",
+                     mail_addresses: [ UserMailAddress.new(address: "test@example.com", confirmed_at: Time.current) ])
+        u.build_member(name: "元の名前")
+        u.save!
+        u
+      end
+
+      it "パスワードを指定せずにsaveできる" do
+        expect(user.save).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- PR #62 で `has_secure_password validations: false` に変更した際、パスワードのpresence検証から `on: :create` 相当の制約が失われ、既存ユーザーの更新時にもパスワードが必須になっていた
- モデルのバリデーションに `persisted?` 条件を追加し、コントローラの空パスワード削除ワークアラウンドも除去

## 変更内容
- `User` モデル: `validates :password, presence: true, unless: -> { provisional? || persisted? }`
- `Admin::UsersController#user_params`: 空パスワード削除処理を除去
- `ProfilesController#profile_params`: 同上
- `spec/models/user_spec.rb`: 既存ユーザーがパスワードなしでsaveできるテストを追加

## Test plan
- [x] RSpec全件パス（37 examples, 0 failures）
- [x] RuboCop通過
- [x] プロフィール編集がパスワードなしで更新できることを動作確認済み