### PR TITLE
ダッシュボードのURLを / に統一

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,6 @@ class ApplicationController < ActionController::Base
     end
 
     def default_after_authentication_url
-      dashboard_path
+      root_path
     end
 end

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -14,7 +14,7 @@ class AttendancesController < ApplicationController
     @attendance.assign_attributes(attendance_params)
 
     if @attendance.save
-      redirect_to dashboard_path, notice: I18n.t("messages.update.success", model: Attendance.model_name.human)
+      redirect_to root_path, notice: I18n.t("messages.update.success", model: Attendance.model_name.human)
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -7,7 +7,7 @@ class ConfirmationsController < ApplicationController
     if mail_address
       mail_address.confirm!
       start_new_session_for mail_address.user
-      redirect_to dashboard_path, notice: "メールアドレスの確認が完了しました"
+      redirect_to root_path, notice: "メールアドレスの確認が完了しました"
     else
       redirect_to new_session_path, alert: "確認リンクが無効です"
     end

--- a/app/models/announcement_template.rb
+++ b/app/models/announcement_template.rb
@@ -58,8 +58,8 @@ class AnnouncementTemplate < ApplicationRecord
     result.gsub!("{{会場案内}}", venue_details.join("\n\n"))
 
     # ダッシュボードURL
-    dashboard_url = Rails.application.routes.url_helpers.dashboard_url
-    result.gsub!("{{ダッシュボードURL}}", dashboard_url)
+    root_url = Rails.application.routes.url_helpers.root_url
+    result.gsub!("{{ダッシュボードURL}}", root_url)
 
     # サインアップURL
     if result.include?("{{サインアップURL}}")

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="w-full max-w-2xl mx-auto">
   <div class="mb-4">
-    <%= link_to "← ダッシュボードに戻る", dashboard_path, class: "text-blue-600 hover:text-blue-700 text-sm" %>
+    <%= link_to "← ダッシュボードに戻る", root_path, class: "text-blue-600 hover:text-blue-700 text-sm" %>
   </div>
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-900"><%= @event.headline %></h1>
@@ -53,7 +53,7 @@
     </div>
 
     <div class="px-4 py-3 bg-gray-50 text-right sm:px-6 space-x-3 sm:rounded-b-lg">
-      <%= link_to "キャンセル", dashboard_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+      <%= link_to "キャンセル", root_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
       <%= form.submit "保存", class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer" %>
     </div>
   <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -3,7 +3,7 @@
     <div class="container mx-auto px-5">
       <div class="flex justify-between items-center h-16">
         <div class="flex items-center space-x-4 md:space-x-8">
-          <%= link_to dashboard_path, class: "text-lg md:text-xl font-bold text-gray-900 truncate hover:text-gray-700" do %>
+          <%= link_to root_path, class: "text-lg md:text-xl font-bold text-gray-900 truncate hover:text-gray-700" do %>
             <%= Setting.instance.circle_name %>
           <% end %>
           <div class="flex items-center space-x-2 md:space-x-4">

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -75,7 +75,7 @@
     </div>
 
     <div class="flex justify-end gap-3">
-      <%= link_to "キャンセル", dashboard_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+      <%= link_to "キャンセル", root_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
       <%= form.submit "更新", class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer" %>
     </div>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,6 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "dashboard#index"
 
-  # Dashboard for members
-  get "dashboard", to: "dashboard#index"
-
   # Profile
   resource :profile, only: [ :edit, :update ]
 


### PR DESCRIPTION
## Summary
- `/dashboard` ルートを削除し、ダッシュボードのURLを `/` のみに統一
- `dashboard_path` / `dashboard_url` を `root_path` / `root_url` に置換