### PR TITLE
メール送信元にサークル名を表示し、お知らせメールにreply-toを設定

### DIFF
--- a/app/mailers/announcement_mailer.rb
+++ b/app/mailers/announcement_mailer.rb
@@ -6,7 +6,8 @@ class AnnouncementMailer < ApplicationMailer
     mail(
       to: announcement.to_address,
       bcc: announcement.bcc_addresses,
-      subject: announcement.subject
+      subject: announcement.subject,
+      reply_to: announcement.to_address
     )
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch("MAILER_FROM", "noreply@example.com")
+  default from: -> { "#{Setting.instance.circle_name} <#{ENV.fetch('MAILER_FROM', 'noreply@example.com')}>" }
   layout "mailer"
 end


### PR DESCRIPTION
## Summary
- メールのfromアドレスに「サークル名 <メアド>」形式で表示名を付与し、メーラーでの表示を改善
- お知らせメールにreply-toヘッダーを設定し、返信が管理者に届くようにした

## デプロイ時の対応
`MAILER_FROM` 環境変数を送信元メールアドレスに変更する：
```
fly secrets set MAILER_FROM=jonan@nay3.net
```