### PR TITLE
LINE Login によるサインアップ・ログイン機能

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -22,6 +22,7 @@ class Admin::SettingsController < Admin::BaseController
   private
 
   def setting_params
-    params.require(:setting).permit(:circle_name, :announcement_batch_size, :announcement_daily_quota_threshold, :announcement_retry_interval_hours)
+    params.require(:setting).permit(:circle_name, :announcement_batch_size, :announcement_daily_quota_threshold, :announcement_retry_interval_hours,
+                                     :line_channel_id, :line_channel_secret)
   end
 end

--- a/app/controllers/line_login_controller.rb
+++ b/app/controllers/line_login_controller.rb
@@ -1,0 +1,74 @@
+class LineLoginController < ApplicationController
+  allow_unauthenticated_access
+
+  def authorize
+    state = SecureRandom.urlsafe_base64(32)
+    session[:line_oauth_state] = state
+    session[:line_oauth_context] = {
+      type: params[:context],
+      signup_token: params[:token]
+    }
+
+    client = LineClient.new
+    redirect_to client.authorize_url(state: state, redirect_uri: line_login_callback_url), allow_other_host: true
+  end
+
+  def callback
+    unless params[:state] == session.delete(:line_oauth_state)
+      redirect_to new_session_path, alert: t("line_login.invalid_state")
+      return
+    end
+
+    context = session.delete(:line_oauth_context) || {}
+
+    client = LineClient.new
+    access_token = client.get_access_token(code: params[:code], redirect_uri: line_login_callback_url)
+    profile = client.get_profile(access_token)
+
+    case context["type"]
+    when "signup"
+      handle_signup(profile, context["signup_token"])
+    when "login"
+      handle_login(profile)
+    else
+      redirect_to new_session_path, alert: t("line_login.invalid_context")
+    end
+  rescue => e
+    Rails.logger.error("LINE login error: #{e.message}")
+    redirect_to new_session_path, alert: t("line_login.error")
+  end
+
+  private
+
+  def handle_signup(profile, signup_token)
+    setting = Setting.instance
+    unless setting.signup_token.present? && signup_token == setting.signup_token
+      raise ActionController::RoutingError, "Not Found"
+    end
+
+    user = User.find_by(line_user_id: profile[:user_id])
+
+    if user
+      start_new_session_for(user)
+      redirect_to root_path
+    else
+      user = User.create!(
+        line_user_id: profile[:user_id],
+        role: :member
+      )
+      start_new_session_for(user)
+      redirect_to root_path
+    end
+  end
+
+  def handle_login(profile)
+    user = User.find_by(line_user_id: profile[:user_id])
+
+    if user && !user.disabled?
+      start_new_session_for(user)
+      redirect_to after_authentication_url
+    else
+      redirect_to new_session_path, alert: t("line_login.user_not_found")
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def line_browser?
+    request.user_agent&.include?("Line/")
+  end
+
   def format_with_links(text)
     return "" if text.blank?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
 
   validates :password, length: { maximum: 72 }, allow_blank: true
   validates :password, confirmation: true, allow_blank: true
-  validates :password, presence: true, unless: -> { provisional? || persisted? }
+  validates :password, presence: true, unless: -> { provisional? || persisted? || line_user_id.present? }
 
   scope :active, -> { where(disabled_at: nil) }
   scope :receives_announcements, -> { where(receives_announcements: true) }
@@ -129,6 +129,8 @@ class User < ApplicationRecord
   end
 
   def validate_mail_addresses_count
+    return if line_user_id.present?
+
     if mail_addresses.reject(&:marked_for_destruction?).empty?
       errors.add(:base, "メールアドレスは1件以上必要です")
     end

--- a/app/services/line_client.rb
+++ b/app/services/line_client.rb
@@ -1,0 +1,52 @@
+class LineClient
+  TOKEN_URL = "https://api.line.me/oauth2/v2.1/token"
+  PROFILE_URL = "https://api.line.me/v2/profile"
+
+  def initialize
+    setting = Setting.instance
+    @channel_id = setting.line_channel_id
+    @channel_secret = setting.line_channel_secret
+  end
+
+  def authorize_url(state:, redirect_uri:)
+    params = {
+      response_type: "code",
+      client_id: @channel_id,
+      redirect_uri: redirect_uri,
+      state: state,
+      scope: "profile openid"
+    }
+    "https://access.line.me/oauth2/v2.1/authorize?#{params.to_query}"
+  end
+
+  def get_access_token(code:, redirect_uri:)
+    uri = URI.parse(TOKEN_URL)
+    response = Net::HTTP.post_form(uri, {
+      grant_type: "authorization_code",
+      code: code,
+      redirect_uri: redirect_uri,
+      client_id: @channel_id,
+      client_secret: @channel_secret
+    })
+
+    body = JSON.parse(response.body)
+    raise "LINE token error: #{body['error_description']}" unless response.is_a?(Net::HTTPSuccess)
+
+    body["access_token"]
+  end
+
+  def get_profile(access_token)
+    uri = URI.parse(PROFILE_URL)
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer #{access_token}"
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(request)
+    end
+
+    body = JSON.parse(response.body)
+    raise "LINE profile error: #{body['message']}" unless response.is_a?(Net::HTTPSuccess)
+
+    { user_id: body["userId"], display_name: body["displayName"] }
+  end
+end

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -43,6 +43,22 @@
       </div>
     </div>
 
+    <div class="bg-white shadow sm:rounded-lg mt-6">
+      <div class="px-4 py-5 sm:p-6 space-y-6">
+        <h3 class="text-lg font-medium text-gray-900">LINE Login</h3>
+
+        <div>
+          <%= form.label :line_channel_id, Setting.human_attribute_name(:line_channel_id), class: "block text-sm font-medium text-gray-700 mb-2" %>
+          <%= form.text_field :line_channel_id, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
+        </div>
+
+        <div>
+          <%= form.label :line_channel_secret, Setting.human_attribute_name(:line_channel_secret), class: "block text-sm font-medium text-gray-700 mb-2" %>
+          <%= form.text_field :line_channel_secret, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
+        </div>
+      </div>
+    </div>
+
     <div class="flex justify-end">
       <%= form.submit "更新", class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer" %>
     </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -7,109 +7,119 @@
       </h2>
     </div>
 
-    <div class="rounded-md bg-blue-50 p-4">
-      <p class="text-sm text-blue-700">
-        登録済みの方は<%= link_to "こちらからログイン", new_session_path, class: "font-medium text-blue-700 underline hover:text-blue-600" %>してください。
-      </p>
-    </div>
-
-    <% all_errors = @user.errors.full_messages %>
-    <% if all_errors.any? %>
-      <div class="rounded-md bg-red-50 p-4">
-        <div class="ml-3">
-          <h3 class="text-sm font-medium text-red-800"><%= t('errors.template.header') %></h3>
-          <div class="mt-2 text-sm text-red-700">
-            <ul class="list-disc pl-5 space-y-1">
-              <% all_errors.each do |message| %>
-                <li><%= message %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
+    <% if line_browser? %>
+      <div class="mt-8">
+        <%= link_to line_login_authorize_path(context: "signup", token: params[:token]),
+              class: "group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-green-500 hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-400",
+              data: { turbo: false } do %>
+          LINEで登録
+        <% end %>
       </div>
-    <% end %>
-
-    <%= form_with url: signup_path(token: params[:token]), scope: :user, class: "mt-8 space-y-6" do |form| %>
-      <div class="space-y-4">
-        <div>
-          <div class="mb-2">
-            <%= form.label :name, "お名前（ハンドル可）", class: "text-sm font-medium text-gray-700" %><span class="text-red-500 ml-1">*</span>
-          </div>
-          <%= form.text_field :name,
-                required: true,
-                autofocus: true,
-                value: @user.name,
-                class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
-        </div>
-
-        <div>
-          <div class="mb-2">
-            <%= form.label :email_address, "メールアドレス", class: "text-sm font-medium text-gray-700" %><span class="text-red-500 ml-1">*</span>
-          </div>
-          <%= form.email_field :email_address,
-                required: true,
-                autocomplete: "email",
-                value: @user.email_address,
-                class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
-        </div>
-
-        <div>
-          <%= form.label :organization_name, "所属団体", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= form.text_field :organization_name,
-                value: @user.organization_name,
-                class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
-        </div>
-
-        <div>
-          <%= form.label :rank, "級", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= form.select :rank,
-                options_for_select([["級なし（初心者）", "unknown"], ["F級", "f"], ["E級", "e"], ["D級", "d"], ["C級", "c"], ["B級", "b"], ["A級", "a"]], @user.rank),
-                { include_blank: true },
-                class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
-        </div>
-
-        <div>
-          <%= form.label :description, "自己紹介", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= form.text_area :description,
-                rows: 3,
-                value: @user.description,
-                class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
-        </div>
-
-        <div>
-          <div class="mb-2">
-            <%= form.label :password, "パスワード", class: "text-sm font-medium text-gray-700" %><span class="text-red-500 ml-1">*</span>
-          </div>
-          <%= form.password_field :password,
-                required: true,
-                autocomplete: "new-password",
-                maxlength: 72,
-                class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
-        </div>
-
-        <div>
-          <div class="mb-2">
-            <%= form.label :password_confirmation, "パスワード（確認）", class: "text-sm font-medium text-gray-700" %><span class="text-red-500 ml-1">*</span>
-          </div>
-          <%= form.password_field :password_confirmation,
-                required: true,
-                autocomplete: "new-password",
-                maxlength: 72,
-                class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
-        </div>
-
-        <div class="flex items-center">
-          <%= form.check_box :receives_announcements,
-                checked: @user.receives_announcements.nil? ? true : @user.receives_announcements,
-                class: "h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" %>
-          <%= form.label :receives_announcements, "練習会のお知らせメールを受け取る", class: "ml-2 block text-sm text-gray-700" %>
-        </div>
+    <% else %>
+      <div class="rounded-md bg-blue-50 p-4">
+        <p class="text-sm text-blue-700">
+          登録済みの方は<%= link_to "こちらからログイン", new_session_path, class: "font-medium text-blue-700 underline hover:text-blue-600" %>してください。
+        </p>
       </div>
 
-      <div>
-        <%= form.submit "登録", class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer" %>
-      </div>
+      <% all_errors = @user.errors.full_messages %>
+      <% if all_errors.any? %>
+        <div class="rounded-md bg-red-50 p-4">
+          <div class="ml-3">
+            <h3 class="text-sm font-medium text-red-800"><%= t('errors.template.header') %></h3>
+            <div class="mt-2 text-sm text-red-700">
+              <ul class="list-disc pl-5 space-y-1">
+                <% all_errors.each do |message| %>
+                  <li><%= message %></li>
+                <% end %>
+              </ul>
+            </div>
+          </div>
+        </div>
+      <% end %>
 
+      <%= form_with url: signup_path(token: params[:token]), scope: :user, class: "mt-8 space-y-6" do |form| %>
+        <div class="space-y-4">
+          <div>
+            <div class="mb-2">
+              <%= form.label :name, "お名前（ハンドル可）", class: "text-sm font-medium text-gray-700" %><span class="text-red-500 ml-1">*</span>
+            </div>
+            <%= form.text_field :name,
+                  required: true,
+                  autofocus: true,
+                  value: @user.name,
+                  class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
+          </div>
+
+          <div>
+            <div class="mb-2">
+              <%= form.label :email_address, "メールアドレス", class: "text-sm font-medium text-gray-700" %><span class="text-red-500 ml-1">*</span>
+            </div>
+            <%= form.email_field :email_address,
+                  required: true,
+                  autocomplete: "email",
+                  value: @user.email_address,
+                  class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
+          </div>
+
+          <div>
+            <%= form.label :organization_name, "所属団体", class: "block text-sm font-medium text-gray-700 mb-2" %>
+            <%= form.text_field :organization_name,
+                  value: @user.organization_name,
+                  class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
+          </div>
+
+          <div>
+            <%= form.label :rank, "級", class: "block text-sm font-medium text-gray-700 mb-2" %>
+            <%= form.select :rank,
+                  options_for_select([["級なし（初心者）", "unknown"], ["F級", "f"], ["E級", "e"], ["D級", "d"], ["C級", "c"], ["B級", "b"], ["A級", "a"]], @user.rank),
+                  { include_blank: true },
+                  class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
+          </div>
+
+          <div>
+            <%= form.label :description, "自己紹介", class: "block text-sm font-medium text-gray-700 mb-2" %>
+            <%= form.text_area :description,
+                  rows: 3,
+                  value: @user.description,
+                  class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
+          </div>
+
+          <div>
+            <div class="mb-2">
+              <%= form.label :password, "パスワード", class: "text-sm font-medium text-gray-700" %><span class="text-red-500 ml-1">*</span>
+            </div>
+            <%= form.password_field :password,
+                  required: true,
+                  autocomplete: "new-password",
+                  maxlength: 72,
+                  class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
+          </div>
+
+          <div>
+            <div class="mb-2">
+              <%= form.label :password_confirmation, "パスワード（確認）", class: "text-sm font-medium text-gray-700" %><span class="text-red-500 ml-1">*</span>
+            </div>
+            <%= form.password_field :password_confirmation,
+                  required: true,
+                  autocomplete: "new-password",
+                  maxlength: 72,
+                  class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white placeholder-gray-400 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
+          </div>
+
+          <div class="flex items-center">
+            <%= form.check_box :receives_announcements,
+                  checked: @user.receives_announcements.nil? ? true : @user.receives_announcements,
+                  class: "h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" %>
+            <%= form.label :receives_announcements, "練習会のお知らせメールを受け取る", class: "ml-2 block text-sm text-gray-700" %>
+          </div>
+        </div>
+
+        <div>
+          <%= form.submit "登録", class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer" %>
+        </div>
+
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -177,6 +177,11 @@ ja:
       last_word_connector: "、"
       two_words_connector: "、"
       words_connector: "、"
+  line_login:
+    invalid_state: "認証に失敗しました。もう一度お試しください。"
+    invalid_context: "認証に失敗しました。もう一度お試しください。"
+    error: "LINE認証中にエラーが発生しました。もう一度お試しください。"
+    user_not_found: "このLINEアカウントに紐づくユーザーが見つかりません。"
   time:
     am: 午前
     formats:

--- a/config/locales/models.ja.yml
+++ b/config/locales/models.ja.yml
@@ -65,6 +65,8 @@ ja:
         announcement_batch_size: "お知らせ配信バッチサイズ"
         announcement_daily_quota_threshold: "1日あたりお知らせ配信数上限"
         announcement_retry_interval_hours: "配信リトライ間隔（時間）"
+        line_channel_id: "LINE Channel ID"
+        line_channel_secret: "LINE Channel Secret"
       announcement_delivery:
         addresses: "送信先アドレス"
         failed_addresses: "失敗アドレス"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   get "signup/:token", to: "registrations#new", as: :signup
   post "signup/:token", to: "registrations#create"
 
+  get "line_login/authorize", to: "line_login#authorize", as: :line_login_authorize
+  get "line_login/callback", to: "line_login#callback", as: :line_login_callback
+
   get "confirm", to: "confirmations#show"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20260315090939_add_line_user_id_to_users.rb
+++ b/db/migrate/20260315090939_add_line_user_id_to_users.rb
@@ -1,0 +1,6 @@
+class AddLineUserIdToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :line_user_id, :string
+    add_index :users, :line_user_id, unique: true, where: "line_user_id IS NOT NULL"
+  end
+end

--- a/db/migrate/20260315214418_add_line_settings_to_settings.rb
+++ b/db/migrate/20260315214418_add_line_settings_to_settings.rb
@@ -1,0 +1,6 @@
+class AddLineSettingsToSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :settings, :line_channel_id, :string
+    add_column :settings, :line_channel_secret, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_12_000350) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_15_214418) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -38,8 +38,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_000350) do
     t.string "event", default: "requested", null: false
     t.string "resend_id", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_mail_address_id"
     t.index ["announcement_delivery_id"], name: "idx_on_announcement_delivery_id_8951ba860a"
     t.index ["resend_id"], name: "index_announcement_delivery_results_on_resend_id", unique: true
+    t.index ["user_mail_address_id"], name: "index_announcement_delivery_results_on_user_mail_address_id"
   end
 
   create_table "announcement_templates", force: :cascade do |t|
@@ -125,6 +127,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_000350) do
     t.integer "announcement_retry_interval_hours", default: 2, null: false
     t.string "circle_name"
     t.datetime "created_at", null: false
+    t.string "line_channel_id"
+    t.string "line_channel_secret"
     t.string "signup_token"
     t.datetime "updated_at", null: false
   end
@@ -148,12 +152,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_000350) do
     t.datetime "disabled_at"
     t.string "email_address"
     t.datetime "last_accessed_at"
+    t.string "line_user_id"
     t.string "password_digest"
     t.boolean "receives_announcements", default: true
     t.string "role"
     t.datetime "updated_at", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["line_user_id"], name: "index_users_on_line_user_id", unique: true, where: "(line_user_id IS NOT NULL)"
   end
 
   create_table "venues", force: :cascade do |t|
@@ -168,6 +174,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_000350) do
 
   add_foreign_key "announcement_deliveries", "announcements"
   add_foreign_key "announcement_delivery_results", "announcement_deliveries"
+  add_foreign_key "announcement_delivery_results", "user_mail_addresses"
   add_foreign_key "announcements", "announcement_templates"
   add_foreign_key "attendances", "events"
   add_foreign_key "attendances", "players"


### PR DESCRIPTION
## 概要
LINE ブラウザからのユーザーに、LINE アカウントでのサインアップ・ログインを提供する。

## 変更内容
- LINE OAuth 2.0 によるサインアップフロー（ユーザー保存まで）
- LINE Login 設定をサークル設定で管理
- LINE ブラウザ判定ヘルパー
- サインアップ画面の条件分岐（LINE ボタン / 既存フォーム）

## 今後のステップ
- [ ] LINE ログイン機能
- [ ] プロフィール入力フォーム
- [ ] メール確認ロジックの変更（LINE ユーザーはブロックしない）