### PR TITLE
送信キューの定期処理を Fly Scheduled Machines 経由に切り替える

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,23 @@
 * アプリ起動後
   * サークル設定で、サークル名を設定してください。
   * 最初の管理者のメールアドレスやパスワードを変更してください。
+
+### 送信キューの定期処理（Fly.io 前提）
+
+Resend の日次上限等で送信できなかった `AnnouncementDelivery` を時間おきに再試行するため、Fly.io の Scheduled Machines で `AnnouncementDelivery.process_queue!` を定期実行します。
+
+初回セットアップ（`<app>` は `fly.toml` の `app` 値、`<image>` は `fly releases --app <app>` で取得できる現在のイメージ）:
+
+```
+fly machine run <image> \
+  --app <app> \
+  --region nrt \
+  --schedule hourly \
+  -- bin/rails runner "AnnouncementDelivery.process_queue!"
+```
+
+デプロイで新イメージになったら Scheduled Machine も追従させる:
+
+```
+fly machine update <machine-id> --image <new-image> --app <app>
+```

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,7 +1,4 @@
 class Admin::AnnouncementsController < Admin::BaseController
-  skip_forgery_protection only: :process_queue_api
-  skip_before_action :require_admin, only: :process_queue_api
-  before_action :authenticate_api_token!, only: :process_queue_api
   before_action :set_announcement, only: %i[ show edit update destroy send_email deliveries ]
 
   def index
@@ -75,11 +72,6 @@ class Admin::AnnouncementsController < Admin::BaseController
     redirect_to pending_deliveries_admin_announcements_path, notice: t("announcements.process_queue.success")
   end
 
-  def process_queue_api
-    AnnouncementDelivery.process_queue!
-    head :ok
-  end
-
   def send_email
     if @announcement.delivery_started_at?
       redirect_to [ :admin, @announcement ], alert: I18n.t("announcements.send_email.delivery_already_started")
@@ -132,11 +124,6 @@ class Admin::AnnouncementsController < Admin::BaseController
     end
 
     @announcement.apply_template
-  end
-
-  def authenticate_api_token!
-    token = request.headers["Authorization"]&.delete_prefix("Bearer ")
-    head :unauthorized unless token.present? && ActiveSupport::SecurityUtils.secure_compare(token, ENV.fetch("API_TOKEN"))
   end
 
   def set_announcement

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,6 @@ Rails.application.routes.draw do
       collection do
         get :pending_deliveries
         post :process_queue
-        post :process_queue_api
       end
       member do
         post :send_email


### PR DESCRIPTION
## 概要

Resend の日次上限等で送信できなかった `AnnouncementDelivery` を再試行するための定期処理を、外部 API エンドポイント経由から Fly.io Scheduled Machines での内部実行に切り替える。

## 背景

これまで `process_queue_api`（Bearer トークン認証）を外部スケジューラから叩く想定だったが、外部公開エンドポイントとトークン管理を避けるため、Fly.io 内部で `bin/rails runner "AnnouncementDelivery.process_queue!"` を時間おきに実行する方式に変更。

## 変更点

- `Admin::AnnouncementsController#process_queue_api`、関連ルート、`authenticate_api_token!` を削除（`ENV["API_TOKEN"]` も不要に）
- 画面からの手動リトライボタン（`process_queue`）はそのまま残る
- README に Fly Scheduled Machines のセットアップ手順を追記

## 運用手順

マージ・デプロイ後に、README 記載の `fly machine run ... --schedule hourly` で Scheduled Machine を作成する。以降のデプロイでは `fly machine update` でイメージを追従させる必要がある点に注意。