### PR TITLE
README の fly machine run 例を zsh で壊れない形に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fly machine run <image> \
   --app <app> \
   --region nrt \
   --schedule hourly \
-  -- bin/rails runner "AnnouncementDelivery.process_queue!"
+  -- bin/rails runner 'AnnouncementDelivery.process_queue!'
 ```
 
 デプロイで新イメージになったら Scheduled Machine も追従させる:


### PR DESCRIPTION
## 概要

README の Fly Scheduled Machines セットアップコマンド例で、Ruby メソッド呼び出しを囲むクオートをダブル→シングルに変更する。

## 背景

`bin/rails runner "AnnouncementDelivery.process_queue!"` を zsh で実行すると、ダブルクオート内の `!` がヒストリ展開として解釈されて `dquote>` プロンプトになり、そのままコピペでは動かない。シングルクオートであれば `!` がリテラル扱いになり、環境差によるハマりが減る。