### PR TITLE
知人を紹介する機能を追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,6 +345,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -22,6 +22,7 @@ class Admin::SettingsController < Admin::BaseController
   private
 
   def setting_params
-    params.require(:setting).permit(:circle_name, :announcement_batch_size, :announcement_daily_quota_threshold, :announcement_retry_interval_hours)
+    params.require(:setting).permit(:circle_name, :announcement_batch_size, :announcement_daily_quota_threshold, :announcement_retry_interval_hours,
+                                    :line_official_account_url, :referral_share_template)
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,4 +1,13 @@
 class Setting < ApplicationRecord
+  DEFAULT_REFERRAL_SHARE_TEMPLATE = <<~TEXT.strip
+    %{circle_name}に練習に来ませんか？
+    練習会のお知らせはLINE公式アカウントから受け取れます:
+    %{line_url}
+
+    すぐ登録するならこちら:
+    %{signup_url}
+  TEXT
+
   # シングルトンパターン: 1レコードのみ存在
   def self.instance
     Current.setting ||= first_or_create!(circle_name: "サークル名未設定")
@@ -10,5 +19,13 @@ class Setting < ApplicationRecord
 
   def generate_signup_token!
     update!(signup_token: SecureRandom.urlsafe_base64(15))
+  end
+
+  def referral_share_text(circle_name:, signup_url:, line_url:)
+    return "" if referral_share_template.blank?
+    referral_share_template
+      .gsub("%{circle_name}", circle_name.to_s)
+      .gsub("%{signup_url}", signup_url.to_s)
+      .gsub("%{line_url}", line_url.to_s)
   end
 end

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -40,8 +40,40 @@
           <%= form.label :announcement_retry_interval_hours, Setting.human_attribute_name(:announcement_retry_interval_hours), class: "block text-sm font-medium text-gray-700 mb-2" %>
           <%= form.number_field :announcement_retry_interval_hours, min: 1, class: "appearance-none block w-32 px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
         </div>
+
+        <hr class="border-gray-200">
+
+        <div>
+          <%= form.label :line_official_account_url, Setting.human_attribute_name(:line_official_account_url), class: "block text-sm font-medium text-gray-700 mb-2" %>
+          <%= form.url_field :line_official_account_url, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
+        </div>
+
+        <div>
+          <div class="flex items-center justify-between mb-2">
+            <%= form.label :referral_share_template, Setting.human_attribute_name(:referral_share_template), class: "block text-sm font-medium text-gray-700" %>
+            <button type="button" id="reset-referral-template-btn" class="text-xs text-blue-600 hover:text-blue-700 underline cursor-pointer">デフォルトに戻す</button>
+          </div>
+          <%= form.text_area :referral_share_template, rows: 8, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm font-mono" %>
+          <p class="mt-1 text-xs text-gray-500">
+            プレースホルダ: <code class="px-1 py-0.5 bg-gray-100 rounded">%{circle_name}</code> / <code class="px-1 py-0.5 bg-gray-100 rounded">%{line_url}</code> / <code class="px-1 py-0.5 bg-gray-100 rounded">%{signup_url}</code> が紹介画面で置換されます。
+          </p>
+        </div>
       </div>
     </div>
+
+    <script type="application/json" id="referral-template-default"><%== Setting::DEFAULT_REFERRAL_SHARE_TEMPLATE.to_json %></script>
+    <script>
+      (function() {
+        const btn = document.getElementById('reset-referral-template-btn');
+        const textarea = document.querySelector('textarea[name="setting[referral_share_template]"]');
+        const defaultJson = document.getElementById('referral-template-default');
+        if (btn && textarea && defaultJson) {
+          btn.addEventListener('click', function() {
+            textarea.value = JSON.parse(defaultJson.textContent);
+          });
+        }
+      })();
+    </script>
 
     <div class="flex justify-end">
       <%= form.submit "更新", class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer" %>

--- a/config/locales/models.ja.yml
+++ b/config/locales/models.ja.yml
@@ -65,6 +65,8 @@ ja:
         announcement_batch_size: "お知らせ配信バッチサイズ"
         announcement_daily_quota_threshold: "1日あたりお知らせ配信数上限"
         announcement_retry_interval_hours: "配信リトライ間隔（時間）"
+        line_official_account_url: "LINE公式アカウントへのともだち登録URL"
+        referral_share_template: "紹介用文章テンプレート"
       announcement_delivery:
         addresses: "送信先アドレス"
         failed_addresses: "失敗アドレス"

--- a/db/migrate/20260426081929_add_referral_line_settings_to_settings.rb
+++ b/db/migrate/20260426081929_add_referral_line_settings_to_settings.rb
@@ -1,0 +1,24 @@
+class AddReferralLineSettingsToSettings < ActiveRecord::Migration[8.1]
+  DEFAULT_REFERRAL_SHARE_TEMPLATE = <<~TEXT.strip
+    %{circle_name}に練習に来ませんか？
+    練習会のお知らせはLINE公式アカウントから受け取れます:
+    %{line_url}
+
+    すぐ登録するならこちら:
+    %{signup_url}
+  TEXT
+
+  def up
+    add_column :settings, :line_official_account_url, :string
+    add_column :settings, :referral_share_template, :text, default: DEFAULT_REFERRAL_SHARE_TEMPLATE
+
+    # 既存レコードにデフォルト値を反映
+    Setting.reset_column_information
+    Setting.where(referral_share_template: nil).update_all(referral_share_template: DEFAULT_REFERRAL_SHARE_TEMPLATE)
+  end
+
+  def down
+    remove_column :settings, :referral_share_template
+    remove_column :settings, :line_official_account_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_25_223106) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_081929) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -127,6 +127,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_223106) do
     t.integer "announcement_retry_interval_hours", default: 2, null: false
     t.string "circle_name"
     t.datetime "created_at", null: false
+    t.string "line_official_account_url"
+    t.text "referral_share_template", default: "%{circle_name}に練習に来ませんか？\n練習会のお知らせはLINE公式アカウントから受け取れます:\n%{line_url}\n\nすぐ登録するならこちら:\n%{signup_url}"
     t.string "signup_token"
     t.datetime "updated_at", null: false
   end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Setting, type: :model do
+  describe "#referral_share_text" do
+    let(:setting) { Setting.instance }
+
+    context "テンプレートが設定されている場合" do
+      before do
+        setting.update!(referral_share_template: "%{circle_name}へ。LINE: %{line_url} / 登録: %{signup_url}")
+      end
+
+      it "プレースホルダが値で置換される" do
+        result = setting.referral_share_text(
+          circle_name: "テストサークル",
+          signup_url: "https://example.com/signup/abc",
+          line_url: "https://line.me/R/ti/p/@example"
+        )
+        expect(result).to eq "テストサークルへ。LINE: https://line.me/R/ti/p/@example / 登録: https://example.com/signup/abc"
+      end
+    end
+
+    context "テンプレートが空の場合" do
+      before do
+        setting.update!(referral_share_template: "")
+      end
+
+      it "空文字を返す" do
+        result = setting.referral_share_text(
+          circle_name: "テストサークル",
+          signup_url: "https://example.com/signup/abc",
+          line_url: "https://line.me/R/ti/p/@example"
+        )
+        expect(result).to eq ""
+      end
+    end
+
+    context "テンプレートにプレースホルダが含まれない場合" do
+      before do
+        setting.update!(referral_share_template: "固定文言です")
+      end
+
+      it "そのまま返す" do
+        result = setting.referral_share_text(
+          circle_name: "テストサークル",
+          signup_url: "https://example.com/signup/abc",
+          line_url: "https://line.me/R/ti/p/@example"
+        )
+        expect(result).to eq "固定文言です"
+      end
+    end
+  end
+
+  describe "デフォルトテンプレート" do
+    it "新規作成時にデフォルト文言が入る" do
+      Setting.delete_all
+      setting = Setting.instance
+      expect(setting.referral_share_template).to eq Setting::DEFAULT_REFERRAL_SHARE_TEMPLATE
+    end
+  end
+end

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Settings", type: :request do
+  let(:admin_user) do
+    User.create!(
+      email_address: "admin@example.com",
+      password: "password123",
+      role: "admin",
+      confirmed_at: Time.current
+    )
+  end
+
+  let!(:admin_member) { Member.create!(name: "管理者", user: admin_user) }
+
+  before do
+    post session_path, params: { email_address: admin_user.email_address, password: "password123" }
+  end
+
+  describe "GET /admin/setting/edit" do
+    it "200を返す" do
+      get edit_admin_setting_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "LINE公式アカウントURL欄と紹介用文章テンプレート欄が表示される" do
+      get edit_admin_setting_path
+      expect(response.body).to include("setting[line_official_account_url]")
+      expect(response.body).to include("setting[referral_share_template]")
+    end
+  end
+
+  describe "PATCH /admin/setting" do
+    context "LINE URLと紹介テンプレートを更新した場合" do
+      let(:params) do
+        {
+          line_official_account_url: "https://line.me/R/ti/p/@example",
+          referral_share_template: "カスタム文言 %{circle_name}"
+        }
+      end
+
+      it "値が保存される" do
+        patch admin_setting_path, params: { setting: params }
+
+        setting = Setting.instance
+        expect(setting.line_official_account_url).to eq "https://line.me/R/ti/p/@example"
+        expect(setting.referral_share_template).to eq "カスタム文言 %{circle_name}"
+      end
+    end
+
+    context "テンプレートを空文字で更新した場合" do
+      it "空文字が保存される" do
+        patch admin_setting_path, params: { setting: { referral_share_template: "" } }
+
+        setting = Setting.instance
+        expect(setting.referral_share_template).to eq ""
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

サークルのメンバーが知人にcirclendarやサークルのLINE公式アカウントを紹介する導線を追加する。

「知人を紹介」画面に、LINE公式アカウントへのともだち登録URL/QR画像と、circlendar直接登録URL/QRコードを集約し、コピペ・QR読み取りで簡単に共有できるようにする。紹介された人は登録時に「紹介者」を自由記述で書き残せ、紹介者は登録者が最初に参加した練習会の開催日から6ヶ月だけ表示される（誰も編集不可）。

LINE公式アカウントの友だち追加URLにはユーザーごとのパラメータを乗せられないため、紹介者の自動識別は行わず登録時の自由記述に倒す方針。LINE QR画像はサークルあたり1枚なのでPostgresに直接バイナリ保存する（CarrierWave / ActiveStorage は導入しない）。

## 進捗

- [x] サークル設定でLINE公式アカウントURLと紹介用文章テンプレートを編集できるようにする
- [ ] サークル設定でLINE公式アカウントQR画像をアップロードできるようにする
- [ ] 「知人を紹介」画面とナビメニューを追加する
- [ ] 「知人を紹介」画面にcirclendar登録URLのQRコードを表示する
- [ ] 登録時に紹介者を入力できるようにする
- [ ] 管理画面で紹介者を表示する
- [ ] 出席画面のメンバーポップアップで紹介者を表示する